### PR TITLE
fix: notes page no data, page error

### DIFF
--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -13,5 +13,5 @@ export default async function Page() {
     },
   }).then((res) => res.json() as Promise<NoteWrappedPayload>)
 
-  return <Redirect nid={data.data.nid} />
+  return <Redirect nid={data.data?.nid} />
 }


### PR DESCRIPTION
I found that some pages would crash when the project was just created and there was no data. After adding compatibility, it now displays 404

<img width="1130" alt="CleanShot 2023-08-02 at 13 24 39@2x" src="https://github.com/Innei/Shiro/assets/44605072/f4053ed1-bef7-46a6-a581-5505af5f31be">
<img width="1210" alt="CleanShot 2023-08-02 at 13 23 51@2x" src="https://github.com/Innei/Shiro/assets/44605072/d4a9e89b-3413-4325-b362-b01acd8d2605">
