### PR TITLE
fix: socket errors

### DIFF
--- a/src/socket/socket-client.ts
+++ b/src/socket/socket-client.ts
@@ -18,10 +18,8 @@ class SocketClient {
   private router: AppRouterInstance
 
   constructor() {
-    // 如果 GATEWAY_URL 已经包含斜杠，确保它不以斜杠结尾
     const gatewayUrlWithoutTrailingSlash = GATEWAY_URL.replace(/\/$/, '');
 
-    // 拼接路径，确保路径之间没有多余的斜杠
     this.socket = io(`${gatewayUrlWithoutTrailingSlash}/web`, {
       timeout: 10000,
       reconnectionDelay: 3000,

--- a/src/socket/socket-client.ts
+++ b/src/socket/socket-client.ts
@@ -18,13 +18,17 @@ class SocketClient {
   private router: AppRouterInstance
 
   constructor() {
-    this.socket = io(`${GATEWAY_URL}/web`, {
+    // 如果 GATEWAY_URL 已经包含斜杠，确保它不以斜杠结尾
+    const gatewayUrlWithoutTrailingSlash = GATEWAY_URL.replace(/\/$/, '');
+
+    // 拼接路径，确保路径之间没有多余的斜杠
+    this.socket = io(`${gatewayUrlWithoutTrailingSlash}/web`, {
       timeout: 10000,
       reconnectionDelay: 3000,
       autoConnect: false,
       reconnectionAttempts: 3,
       transports: ['websocket'],
-    })
+    });
   }
 
   setRouter(router: AppRouterInstance) {


### PR DESCRIPTION
### Pull Request Template

```javascript
constructor() {
  // 如果 GATEWAY_URL 已经包含斜杠，确保它不以斜杠结尾
  const gatewayUrlWithoutTrailingSlash = GATEWAY_URL.replace(/\/$/, '');

  // 拼接路径
  this.socket = io(`${gatewayUrlWithoutTrailingSlash}/web`, {
    timeout: 10000,
    reconnectionDelay: 3000,
    autoConnect: false,
    reconnectionAttempts: 3,
    transports: ['websocket'],
  });
}
```

### Description
由于环境变量`GATEWAY`URL地址末尾多加了个`/`导致的Socket连接失败
#### 错误信息
无法正常显示网页在线人数
```Socket.io connection error: Invalid namespace.```

#### 排查过程
前端由Vercel直接Fork部署、
服务端首先检查nginx的配置文件，反向代理支持socket连接、[WebSocket 在线测试工具](https://wstool.js.org/)测试相关配置都没问题后
根据浏览器的抓包数据，发现路径多添加了一个`/`，已针对修复。

![50e2a292810bea0004cdcb40889b155f](https://github.com/Innei/Shiro/assets/80184334/86be259a-b95c-4ed9-92a9-01d305f54a4b)

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

添加对shocket路径的检查`GATEWAY_URL`的检查，并对其进行适当处理。
已测试正常

<img width="854" alt="image" src="https://github.com/Innei/Shiro/assets/80184334/8817c01a-3c66-4259-b341-fefe39f9b62e">
