### PR TITLE
Make summary `id` auto-increment and enlarge length of `api_endpoint`

### DIFF
--- a/src/app/api/ai/summary/route.ts
+++ b/src/app/api/ai/summary/route.ts
@@ -58,7 +58,7 @@ export const GET = async (req: NextRequest) => {
       break
     }
   }
-  await sql`create table if not exists summary (id int NOT NULL PRIMARY KEY, api_endpoint varchar(30), summary text, lang varchar(10), modified varchar(30), cid varchar(40))`
+  await sql`create table if not exists summary (id SERIAL PRIMARY KEY, api_endpoint varchar(50), summary text, lang varchar(10), modified varchar(30), cid varchar(40))`
 
   const sqlResult =
     await sql`select * from summary where lang = ${lang} and api_endpoint = ${API_URL} and modified = ${modified} and cid = ${cid}`


### PR DESCRIPTION
### Description

When I enabled chatgpt ai summary, I got the following error in product environment:

```
NeonDbError: db error: ERROR: value too long for type character varying(30)
```

This error is caused by my `api_endpoint` exceeding the field length (30 default). To improve applicability, I think it's a good idea that increasing the length of `api_endpoint` to 50😜.

And then I got another error:

```
NeonDbError: db error: ERROR: null value in column "id" violates not-null constraint
```

I found that `id` was defined as `id int NOT NULL PRIMARY KEY` when creating summary table，but missed the `id` filed while inserting data. I think it's better to define `id` as an auto-increment key. 

So I modified the original creating table SQL to 

```sql
create table if not exists summary (id SERIAL PRIMARY KEY, api_endpoint varchar(50), summary text, lang varchar(10), modified varchar(30), cid varchar(40))
```

All problems were solved!

