### PR TITLE
fix: icons not aligned & modal window height not enough

### DIFF
--- a/src/components/layout/header/internal/HeaderDrawerButton.tsx
+++ b/src/components/layout/header/internal/HeaderDrawerButton.tsx
@@ -36,7 +36,7 @@ export const HeaderDrawerButton = () => {
 
                 <Dialog.Content>
                   <m.dialog
-                    className="fixed left-0 right-0 top-0 z-[12] m-0 block w-full overflow-auto rounded-xl bg-base-100/90 px-3 backdrop-blur-sm"
+                    className="fixed left-0 right-0 top-0 z-[12] m-0 block h-screen w-full overflow-auto rounded-xl bg-base-100/90 px-3 backdrop-blur-sm"
                     initial={{ opacity: 0.8 }}
                     animate={{ opacity: 1 }}
                     exit={{ opacity: 0 }}

--- a/src/components/widgets/post/PostActionAside.tsx
+++ b/src/components/widgets/post/PostActionAside.tsx
@@ -128,7 +128,7 @@ const LikeButton = () => {
     >
       <m.i
         className={clsxm(
-          'hover:text-uk-orange-light hover:opacity-100',
+          'relative flex hover:text-uk-orange-light hover:opacity-100',
           asideButtonStyles.base,
 
           isLiked && 'text-uk-orange-dark',
@@ -145,7 +145,7 @@ const LikeButton = () => {
       >
         <ThumbsupIcon />
         {!!likeCount && (
-          <span className="absolute bottom-[5px] right-0 translate-x-[8px] transform text-[10px]">
+          <span className="absolute bottom-0 right-0 translate-x-[8px] transform text-[10px]">
             <NumberSmoothTransition>{likeCount}</NumberSmoothTransition>
           </span>
         )}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->



### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

修复了移动端导航模态窗的高度不足问题：

![Cleanshot-2023-12-30-at-22 37 56@2x](https://github.com/Innei/Shiro/assets/36695271/66ebd760-7351-4af0-86b3-62cc75de7849)


修复了工具栏的不对齐问题：

before:

![Cleanshot-2023-12-30-at-22 38 46@2x](https://github.com/Innei/Shiro/assets/36695271/478a61bc-00cb-40b9-a21c-24b952cc5cfa)

after:

![Cleanshot-2023-12-30-at-22 39 09@2x](https://github.com/Innei/Shiro/assets/36695271/b084c9be-94f2-45bd-90cf-440584c5cba7)

### Linked Issues

None.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

其他的一个相关问题：

移动端现在导航模态窗高度不足时无法滚动：

![image](https://github.com/Innei/Shiro/assets/36695271/544e6fcd-ab99-4c40-ae37-2b86fc01c2db)
