### PR TITLE
fix: update katex to v0.16.9 and prevent throwing ParseError

### DIFF
--- a/src/components/ui/markdown/parsers/katex.tsx
+++ b/src/components/ui/markdown/parsers/katex.tsx
@@ -42,6 +42,8 @@ const LateX: FC<LateXProps> = (props) => {
 
   const displayMode = mode === 'display'
 
+  const throwOnError = false // render unsupported commands as text instead of throwing a `ParseError`
+
   useInsertionEffect(() => {
     loadStyleSheet(
       'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css',
@@ -50,7 +52,7 @@ const LateX: FC<LateXProps> = (props) => {
       'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js',
     ).then(() => {
       // @ts-ignore
-      const html = window.katex.renderToString(children, { displayMode })
+      const html = window.katex.renderToString(children, { displayMode, throwOnError })
       setHtml(html)
     })
   }, [])

--- a/src/components/ui/markdown/parsers/katex.tsx
+++ b/src/components/ui/markdown/parsers/katex.tsx
@@ -44,10 +44,10 @@ const LateX: FC<LateXProps> = (props) => {
 
   useInsertionEffect(() => {
     loadStyleSheet(
-      'https://lf9-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/katex.min.css',
+      'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css',
     )
     loadScript(
-      'https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/katex.min.js',
+      'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js',
     ).then(() => {
       // @ts-ignore
       const html = window.katex.renderToString(children, { displayMode })


### PR DESCRIPTION
Update katex to v0.16.9 and prevent throwing `ParseError`  when it encounters an unsupported command or invalid LaTeX.

Actually there are two options if katex encounters an unsupported command：

1. `throwOnError = true`: Katex will throw a `ParseError` and we catch the error for further processing;
2. `throwOnError = false`: Katex will render unsupported commands as text in `errorColor`.

Here I choose the latter. It expose issues to the front-end so that I can find the error at a glance.