### PR TITLE
feat: 添加一些windows上的进程名称

### DIFF
--- a/src/components/layout/header/internal/Activity.tsx
+++ b/src/components/layout/header/internal/Activity.tsx
@@ -49,7 +49,7 @@ const appDescription = {
   umamusume: '启动！',
   WindowsTerminal: 'del /f /s /q c:/ (不是',
   卡拉彼丘: '启动！',
-  'Yuanshen.exe': '启动！',
+  Yuanshen: '启动！',
 } as any
 const appLabels: { [app: string]: string } = {
   'Activity Monitor': 'activity',
@@ -130,12 +130,18 @@ const appLabels: { [app: string]: string } = {
   cmusic: 'cmusic',
 
   'Microsoft Edge': 'edge',
+  msedge: 'edge',
   firefox: 'firefox',
   idea64: 'idea',
-  'Explorer.EXE': 'windows_explorer',
+  explorer: 'windows_explorer',
   WindowsTerminal: 'windows_terminal',
   卡拉彼丘: 'calatopia',
-  'Yuanshen.exe': 'genshin',
+  Yuanshen: 'genshin',
+  chrome: 'chrome',
+  WINWORD: 'word',
+  EXCEL: 'excel',
+  POWERPNT: 'powerpoint',
+  ONENOTE: 'onenote',
 }
 // autocorrect: true
 export const Activity = memo(() => {

--- a/src/components/layout/header/internal/Activity.tsx
+++ b/src/components/layout/header/internal/Activity.tsx
@@ -133,6 +133,7 @@ const appLabels: { [app: string]: string } = {
   msedge: 'edge',
   firefox: 'firefox',
   idea64: 'idea',
+  'Explorer.EXE': 'windows_explorer',
   explorer: 'windows_explorer',
   WindowsTerminal: 'windows_terminal',
   卡拉彼丘: 'calatopia',

--- a/src/components/layout/header/internal/Activity.tsx
+++ b/src/components/layout/header/internal/Activity.tsx
@@ -139,10 +139,10 @@ const appLabels: { [app: string]: string } = {
   卡拉彼丘: 'calatopia',
   Yuanshen: 'genshin',
   chrome: 'chrome',
-  WINWORD: 'word',
-  EXCEL: 'excel',
-  POWERPNT: 'powerpoint',
-  ONENOTE: 'onenote',
+  'WINWORD.EXE': 'word',
+  'EXCEL.EXE': 'excel',
+  'POWERPNT.EXE': 'powerpoint',
+  'ONENOTE.EXE': 'onenote',
 }
 // autocorrect: true
 export const Activity = memo(() => {


### PR DESCRIPTION
### Description

添加/更改Activity中windows进程名称

### Additional context

OS: Windows 11 Professional 23H2 (Build 22631.3085)

进程和应用名修改：
- Yuanshen（曾用：Yuanshen.exe）—— reporter将小写的`.exe`删除
- msedge —— windows下的edge浏览器进程为`msedge.exe`
- explorer —— `explorer.exe`或者`Explorer.EXE`都有可能出现，还不知道原因
- chrome —— windows下为全小写
- WINWORD, EXCEL, POWERPNT, ONENOTE —— windows下对应office套件的进程