### PR TITLE
chore: fix local production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev": "cross-env NODE_ENV=development next dev -p 2323",
     "dev:turbo": "cross-env NODE_ENV=development next dev -p 2323 --turbo",
     "analyze": "cross-env NODE_ENV=production ANALYZE=true BUNDLE_ANALYZE=browser next build",
-    "build": "cross-env NODE_ENV=production next build",
+    "build": "cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=4096 next build",
     "build:ci": "cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=4096 NEXT_TELEMETRY_DISABLED=1 CI=true next build",
     "lint": "eslint --ext .ts,.tsx --ignore-path .gitignore . --fix",
     "prod:pm2": "cross-env NODE_ENV=production pm2 restart ecosystem.config.js",


### PR DESCRIPTION
添加 `NODE_OPTIONS=--max_old_space_size=4096` 以防止本地 build 时出现 `Javascript Heap out of memory`
