### PR TITLE
feat: Add support for unknown languages & style: Update code line for…

### DIFF
--- a/src/components/modules/shared/CodeBlock.tsx
+++ b/src/components/modules/shared/CodeBlock.tsx
@@ -4,8 +4,6 @@ import { useIsomorphicLayoutEffect } from 'foxact/use-isomorphic-layout-effect'
 import dynamic from 'next/dynamic'
 import type { ReactNode } from 'react'
 
-import { HighLighterPrismCdn } from '~/components/ui/code-highlighter'
-import { isSupportedShikiLang } from '~/components/ui/code-highlighter/shiki/utils'
 import { ExcalidrawLoading } from '~/components/ui/excalidraw/ExcalidrawLoading'
 
 import { BlockLoading } from './BlockLoading'
@@ -54,17 +52,12 @@ export const CodeBlockRender = (props: {
         )
       }
       default: {
-        const lang = props.lang
-        if (lang && isSupportedShikiLang(lang)) {
-          const ShikiHighLighter = dynamic(() =>
-            import('~/components/ui/code-highlighter/shiki/Shiki').then(
-              (mod) => mod.ShikiHighLighter,
-            ),
-          )
-          return <ShikiHighLighter {...props} />
-        }
-
-        return <HighLighterPrismCdn {...props} />
+        const ShikiHighLighter = dynamic(() =>
+          import('~/components/ui/code-highlighter/shiki/Shiki').then(
+            (mod) => mod.ShikiHighLighter,
+          ),
+        )
+        return <ShikiHighLighter {...props} />
       }
     }
   }, [props])

--- a/src/components/modules/shared/CodeBlock.tsx
+++ b/src/components/modules/shared/CodeBlock.tsx
@@ -4,6 +4,8 @@ import { useIsomorphicLayoutEffect } from 'foxact/use-isomorphic-layout-effect'
 import dynamic from 'next/dynamic'
 import type { ReactNode } from 'react'
 
+import { HighLighterPrismCdn } from '~/components/ui/code-highlighter'
+import { isSupportedShikiLang } from '~/components/ui/code-highlighter/shiki/utils'
 import { ExcalidrawLoading } from '~/components/ui/excalidraw/ExcalidrawLoading'
 
 import { BlockLoading } from './BlockLoading'
@@ -52,12 +54,17 @@ export const CodeBlockRender = (props: {
         )
       }
       default: {
-        const ShikiHighLighter = dynamic(() =>
-          import('~/components/ui/code-highlighter/shiki/Shiki').then(
-            (mod) => mod.ShikiHighLighter,
-          ),
-        )
-        return <ShikiHighLighter {...props} />
+        const lang = props.lang
+        if (lang && isSupportedShikiLang(lang)) {
+          const ShikiHighLighter = dynamic(() =>
+            import('~/components/ui/code-highlighter/shiki/Shiki').then(
+              (mod) => mod.ShikiHighLighter,
+            ),
+          )
+          return <ShikiHighLighter {...props} />
+        }
+
+        return <HighLighterPrismCdn {...props} />
       }
     }
   }, [props])

--- a/src/components/ui/code-highlighter/shiki/Shiki.module.css
+++ b/src/components/ui/code-highlighter/shiki/Shiki.module.css
@@ -17,7 +17,7 @@
     }
 
     .line {
-      @apply block px-4;
+      @apply block;
     }
 
     .highlighted,

--- a/src/components/ui/code-highlighter/shiki/Shiki.tsx
+++ b/src/components/ui/code-highlighter/shiki/Shiki.tsx
@@ -132,7 +132,7 @@ export const ShikiHighLighter: FC<Props> = (props) => {
       {!filename && !!language && (
         <div
           aria-hidden
-          className="pointer-events-none absolute bottom-3 right-3 text-sm opacity-60"
+          className="pointer-events-none absolute bottom-3 right-3 z-10 text-sm opacity-60"
         >
           {language.toUpperCase()}
         </div>

--- a/src/components/ui/code-highlighter/shiki/Shiki.tsx
+++ b/src/components/ui/code-highlighter/shiki/Shiki.tsx
@@ -13,7 +13,6 @@ import type { HighlighterCore } from 'shiki'
 
 import { getViewport } from '~/atoms/hooks'
 import { AutoResizeHeight } from '~/components/modules/shared/AutoResizeHeight'
-import { isSupportedShikiLang } from '~/components/ui/code-highlighter/shiki/utils'
 import { useMaskScrollArea } from '~/hooks/shared/use-mask-scrollarea'
 import { clsxm } from '~/lib/helper'
 
@@ -103,10 +102,7 @@ export const ShikiHighLighter: FC<Props> = (props) => {
     return codeHighlighter(highlighter, {
       attrs: attrs || '',
       code: value,
-      lang:
-        language && isSupportedShikiLang(language)
-          ? language.toLowerCase()
-          : '',
+      lang: language ? language.toLowerCase() : '',
     })
   }, [attrs, language, value, highlighter])
 

--- a/src/components/ui/code-highlighter/shiki/Shiki.tsx
+++ b/src/components/ui/code-highlighter/shiki/Shiki.tsx
@@ -13,6 +13,7 @@ import type { HighlighterCore } from 'shiki'
 
 import { getViewport } from '~/atoms/hooks'
 import { AutoResizeHeight } from '~/components/modules/shared/AutoResizeHeight'
+import { isSupportedShikiLang } from '~/components/ui/code-highlighter/shiki/utils'
 import { useMaskScrollArea } from '~/hooks/shared/use-mask-scrollarea'
 import { clsxm } from '~/lib/helper'
 
@@ -64,9 +65,8 @@ export const ShikiHighLighter: FC<Props> = (props) => {
           () => import('shiki/langs/vue.mjs'),
           () => import('shiki/langs/html.mjs'),
           () => import('shiki/langs/asm.mjs'),
-          () => import('shiki/langs/bash.mjs'),
+          () => import('shiki/langs/shell.mjs'),
           () => import('shiki/langs/ps.mjs'),
-          () => import('shiki/langs/ps1.mjs'),
         ],
         loadWasm: getWasm,
       })
@@ -103,7 +103,7 @@ export const ShikiHighLighter: FC<Props> = (props) => {
     return codeHighlighter(highlighter, {
       attrs: attrs || '',
       code: value,
-      lang: language || '',
+      lang: language && isSupportedShikiLang(language) ? language : '',
     })
   }, [attrs, language, value, highlighter])
 
@@ -152,7 +152,7 @@ export const ShikiHighLighter: FC<Props> = (props) => {
           <div
             ref={setCodeBlockRef}
             className={clsxm(
-              'relative max-h-[50vh] w-full overflow-auto scrollbar-none',
+              'relative max-h-[50vh] w-full overflow-auto px-4 scrollbar-none',
               !isCollapsed ? '!max-h-[100%]' : isOverflow ? maskClassName : '',
             )}
             dangerouslySetInnerHTML={

--- a/src/components/ui/code-highlighter/shiki/Shiki.tsx
+++ b/src/components/ui/code-highlighter/shiki/Shiki.tsx
@@ -103,7 +103,10 @@ export const ShikiHighLighter: FC<Props> = (props) => {
     return codeHighlighter(highlighter, {
       attrs: attrs || '',
       code: value,
-      lang: language && isSupportedShikiLang(language) ? language : '',
+      lang:
+        language && isSupportedShikiLang(language)
+          ? language.toLowerCase()
+          : '',
     })
   }, [attrs, language, value, highlighter])
 

--- a/src/components/ui/code-highlighter/shiki/utils.tsx
+++ b/src/components/ui/code-highlighter/shiki/utils.tsx
@@ -59,5 +59,5 @@ export const parseFilenameFromAttrs = (attrs: string) => {
 }
 
 export const isSupportedShikiLang = (lang: string) => {
-  return Object.keys(bundledLanguages).includes(lang)
+  return Object.keys(bundledLanguages).includes(lang.toLowerCase())
 }

--- a/src/components/ui/code-highlighter/shiki/utils.tsx
+++ b/src/components/ui/code-highlighter/shiki/utils.tsx
@@ -1,4 +1,3 @@
-import { bundledLanguages } from 'shiki'
 import type {
   BundledLanguage,
   BundledTheme,
@@ -59,5 +58,31 @@ export const parseFilenameFromAttrs = (attrs: string) => {
 }
 
 export const isSupportedShikiLang = (lang: string) => {
-  return Object.keys(bundledLanguages).includes(lang.toLowerCase())
+  return [
+    'javascript',
+    'typescript',
+    'ts',
+    'js',
+    'css',
+    'tsx',
+    'jsx',
+    'json',
+    'sql',
+    'markdown',
+    'vue',
+    'rust',
+    'go',
+    'cpp',
+    'c',
+    'html',
+    'asm',
+    'bash',
+    'ps',
+    'ps1',
+    // plain text
+    'text',
+    'plaintext',
+    'txt',
+    'plain',
+  ].includes(lang.toLowerCase())
 }

--- a/src/components/ui/code-highlighter/shiki/utils.tsx
+++ b/src/components/ui/code-highlighter/shiki/utils.tsx
@@ -1,3 +1,4 @@
+import { bundledLanguages } from 'shiki'
 import type {
   BundledLanguage,
   BundledTheme,
@@ -58,31 +59,5 @@ export const parseFilenameFromAttrs = (attrs: string) => {
 }
 
 export const isSupportedShikiLang = (lang: string) => {
-  return [
-    'javascript',
-    'typescript',
-    'ts',
-    'js',
-    'css',
-    'tsx',
-    'jsx',
-    'json',
-    'sql',
-    'markdown',
-    'vue',
-    'rust',
-    'go',
-    'cpp',
-    'c',
-    'html',
-    'asm',
-    'bash',
-    'ps',
-    'ps1',
-    // plain text
-    'text',
-    'plaintext',
-    'txt',
-    'plain',
-  ].includes(lang)
+  return Object.keys(bundledLanguages).includes(lang)
 }


### PR DESCRIPTION
…matting

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

通过 `bundledLanguages` 来获取 Shiki 支持的全部语言，Ref: https://github.com/shikijs/shiki/issues/583

对于不支持的语言，在使用 Shiki 渲染前，设置语言为空，这会触发 plain text 渲染。但是保持语言标签的传递：

![image](https://github.com/Innei/Shiro/assets/36695271/de8c34e0-9e72-4d66-b61c-123d5dda5644)

移除了代码渲染组件的判断，这可能需要进一步的代码删除工作。

> 如果认为存在 CodeHighlighter 可以渲染，但是 Shiki 无法渲染的情况，可能需要再改改逻辑？

修了代码行的 padding 位置，从而使得滚动条不再触碰边界：

Before:

![image](https://github.com/Innei/Shiro/assets/36695271/0b9c3adf-6f74-4980-886e-82eeb05a535d)

After:

![image](https://github.com/Innei/Shiro/assets/36695271/630466aa-9b7d-4fee-9250-f80787e1fbc0)

~~不过还发现了一个新问题，现在右侧语言 TAG 是不是有遮挡的问题（下个 commit 加个 z-index）~~ Fixed.：

![image](https://github.com/Innei/Shiro/assets/36695271/a921a4d7-3be7-49b4-ac7f-c1d7134008e9)


### Linked Issues


### Additional context

另外还有个问题，我感觉现有的动态导入 shiki 的对应 mjs 是不是有点太繁琐了，能否自动导入所有 shiki 可用的 mjs 呢？

<!-- e.g. is there anything you'd like reviewers to focus on? -->
