### PR TITLE
fix: add say background

### DIFF
--- a/src/app/(app)/thinking/page.tsx
+++ b/src/app/(app)/thinking/page.tsx
@@ -210,12 +210,12 @@ const List = () => {
                 </div>
 
                 <div
-                className={clsx(
-                  'relative inline-block rounded-xl px-2 py-1 text-zinc-800 dark:text-zinc-200',
-                  'rounded-bl-sm bg-zinc-600/5 dark:bg-zinc-500/20',
-                  'max-w-[calc(100%-3rem)]',
-                )}
-              >
+                  className={clsx(
+                    'relative inline-block rounded-xl px-2 py-1 text-zinc-800 dark:text-zinc-200',
+                    'rounded-tl-sm bg-zinc-600/5 dark:bg-zinc-500/20',
+                    'max-w-[calc(100%-3rem)]',
+                  )}
+                >
                   <Markdown allowsScript>{item.content}</Markdown>
 
                   {!!item.ref && (

--- a/src/app/(app)/thinking/page.tsx
+++ b/src/app/(app)/thinking/page.tsx
@@ -209,7 +209,13 @@ const List = () => {
                   </span>
                 </div>
 
-                <div className="Comment_comment__message__vO6iH relative inline-block rounded-xl px-2 py-1 text-zinc-800 dark:text-zinc-200 rounded-bl-sm bg-zinc-600/5 dark:bg-zinc-500/20 max-w-[calc(100%-3rem)]">
+                <div
+                className={clsx(
+                  'relative inline-block rounded-xl px-2 py-1 text-zinc-800 dark:text-zinc-200',
+                  'rounded-bl-sm bg-zinc-600/5 dark:bg-zinc-500/20',
+                  'max-w-[calc(100%-3rem)]',
+                )}
+              >
                   <Markdown allowsScript>{item.content}</Markdown>
 
                   {!!item.ref && (

--- a/src/app/(app)/thinking/page.tsx
+++ b/src/app/(app)/thinking/page.tsx
@@ -209,7 +209,7 @@ const List = () => {
                   </span>
                 </div>
 
-                <div className="my-4 leading-relaxed">
+                <div className="Comment_comment__message__vO6iH relative inline-block rounded-xl px-2 py-1 text-zinc-800 dark:text-zinc-200 rounded-bl-sm bg-zinc-600/5 dark:bg-zinc-500/20 max-w-[calc(100%-3rem)]">
                   <Markdown allowsScript>{item.content}</Markdown>
 
                   {!!item.ref && (


### PR DESCRIPTION
Added background style to the thinking and speaking section to highlight the main content, making it look less bizarre
![](https://cdn.jsdelivr.net/gh/hanwuhw/live-page@main/20240327091706.png)
