### PR TITLE
fix: broswer support check

### DIFF
--- a/src/app/browser-support.tsx
+++ b/src/app/browser-support.tsx
@@ -7,7 +7,7 @@ import { TrackerAction } from '~/constants/tracker'
 function isSupportedBrowser() {
   const ua = navigator.userAgent
   const browserRegex = /(?:Chrome|Edg|Firefox|Opera|Safari)\/(\d+)/
-  const safariRegex = /Version\/(\d+) Safari/ // Safari 浏览器的版本号不同
+  const safariRegex = /Version\/([\d.]+).*Safari/ // Safari 浏览器的版本号不同
 
   // 检测 Safari
   if (ua.includes('Safari') && !ua.includes('Chrome') && !ua.includes('Edg')) {


### PR DESCRIPTION
修复safari版本号匹配问题，目前最新版本safari浏览器会提示“您的浏览器版本过低，请升级浏览器”

测试设备：

iPhone 8 Plus - iOS 15.6
iPhone 14 Pro Max - iOS 17.4
Mac Mini - Safari Version : 17.2.1 (19617.1.17.11.12)

测试于[https://idog.dev](https://idog.dev) 

Shiro版本：Docker innei/shiro:latest