### PR TITLE
fix: footer GatewayInfo divider

### DIFF
--- a/src/components/layout/footer/FooterInfo.tsx
+++ b/src/components/layout/footer/FooterInfo.tsx
@@ -206,7 +206,11 @@ const FooterBottom = async () => {
           </>
         )}
 
-        <Divider className="inline" />
+        {icp ? (
+          <Divider className="inline" />
+        ) : (
+          <Divider className="hidden md:inline" />
+        )}
         <GatewayInfo />
         {/* {!!lastVisitor && (
           <>


### PR DESCRIPTION
修复在没有配置icp信息的情况下，移动端页尾的GatewayInfo前面会多出一条分割线的问题。