### PR TITLE
fix: clerk card padding top

### DIFF
--- a/src/styles/clerk.css
+++ b/src/styles/clerk.css
@@ -208,6 +208,9 @@
     @apply text-zinc-200;
   }
 }
-.cl-card {
+.cl-card:not(.cl-userButtonPopoverCard) {
   @apply pt-10;
+}
+.cl-userProfile-root .cl-card .cl-scrollBox + div {
+  @apply hidden;
 }


### PR DESCRIPTION
登录情况下点击右上角头像弹出的卡片不应该有pt-10这个样式，这里修一下。

顺便把manage account弹窗左边的secured by clerk隐藏掉。