### PR TITLE
fix(toast): add 'use client' directive to resolve Vercel deployment SSR issue

### DIFF
--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,3 +1,4 @@
+'use client'
 import type { JSX } from 'react'
 import { jsx } from 'react/jsx-runtime'
 import type { ExternalToast } from 'sonner'


### PR DESCRIPTION
### Description

English:
This PR addresses a server-side rendering (SSR) issue encountered during Vercel deployment by adding the 'use client' directive to the Toast component. The error occurred because the Toast component was attempting to access browser-specific APIs during server-side rendering, which is not supported.

Changes made:
- Added 'use client' directive to the Toast component
- Ensures the component is properly rendered on the client side
- Resolves deployment errors on Vercel platform

### Additional Context

English:
The Toast component requires access to browser APIs for proper functionality. By adding the 'use client' directive, we ensure that the component is only rendered on the client side, preventing SSR-related errors during deployment.

This change:
- Maintains component functionality while resolving deployment issues
- Does not affect the user experience or component behavior
- Follows Next.js best practices for client-side components